### PR TITLE
Remove call to plt.legend() in ndmap's plot() method

### DIFF
--- a/gammapy/maps/region/ndmap.py
+++ b/gammapy/maps/region/ndmap.py
@@ -159,9 +159,6 @@ class RegionNDMap(Map):
         if "energy" in axis_name:
             ax.set_yscale("log", nonpositive="clip")
 
-        if len(self.geom.axes) > 1:
-            plt.legend()
-
         return ax
 
     def plot_hist(self, ax=None, **kwargs):


### PR DESCRIPTION
For LC, datasets consist on two axes: time and energy. Making a call to plt.legend() without arguments triggers the following the following message in gammapy:

"No artists with labels found to put in legend.  Note that artists whose label start with an underscore are ignored when legend() is called with no argument.."

If you plot N FluxPoints, the message is printed N times. 

Related issue: #5510
